### PR TITLE
Add dynamic context menu items

### DIFF
--- a/components/ForceGraph.vue
+++ b/components/ForceGraph.vue
@@ -449,7 +449,7 @@ function updateNodes() {
     .on('contextmenu', (event: MouseEvent, d: GraphNode) => {
       event.preventDefault();
       contextMenuNodeId.value = d.id;
-      if (contextMenu.value) contextMenu.value.show(event);
+      if (contextMenu.value) contextMenu.value.show(event, d.text);
       console.log('Node right-clicked:', d.id);
     });
   

--- a/server/api/context-menu.ts
+++ b/server/api/context-menu.ts
@@ -1,0 +1,41 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+export default defineEventHandler(async (event) => {
+  if (event.node.req.method !== 'POST') {
+    throw createError({ statusCode: 405, statusMessage: 'Method Not Allowed' })
+  }
+
+  const { public: { GEMINI_API_KEY } } = useRuntimeConfig()
+  if (!GEMINI_API_KEY) {
+    throw createError({ statusCode: 500, statusMessage: 'Missing Gemini API Key configuration' })
+  }
+
+  const { text } = await readBody<{ text: string }>(event)
+  if (!text) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing node text' })
+  }
+
+  const prompt = `The user is exploring \"${text}\". Suggest 3 context menu categories with 3 actions each to further explore this concept. Return JSON like [{"category":"Category","items":["Item1","Item2"]}].`
+
+  const genAI = new GoogleGenerativeAI(GEMINI_API_KEY)
+  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-lite' })
+
+  try {
+    const result = await model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }]
+    })
+    const raw = result.response.text()
+    const cleaned = raw.replace(/```json\n?|\n```/g, '').trim()
+    let categories
+    try {
+      categories = JSON.parse(cleaned)
+    } catch (err) {
+      throw createError({ statusCode: 500, statusMessage: 'Invalid JSON response from AI' })
+    }
+    return { categories }
+  } catch (error: any) {
+    const message = error.response?.data?.error?.message || error.message || 'Failed to generate context menu'
+    throw createError({ statusCode: 500, statusMessage: `ContextMenu Error: ${message}` })
+  }
+})

--- a/services/contextMenuService.ts
+++ b/services/contextMenuService.ts
@@ -1,0 +1,23 @@
+export interface ContextMenuCategory {
+  category: string
+  items: string[]
+}
+
+export async function getContextMenuOptions(text: string): Promise<ContextMenuCategory[]> {
+  try {
+    const response = await fetch('/api/context-menu', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    })
+    if (!response.ok) {
+      const errText = await response.text()
+      throw new Error(`Context menu API error (${response.status}): ${errText}`)
+    }
+    const data = await response.json() as { categories: ContextMenuCategory[] }
+    return data.categories
+  } catch (error) {
+    console.error('Error fetching context menu options:', error)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- expand `NodeContextMenu` to load dynamic categories
- request menu options from new `getContextMenuOptions` service
- call Gemini from new `/api/context-menu` route
- update `ForceGraph` integration

## Testing
- `pnpm lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6841554459f8832397e83bcf8fd8c750