### PR TITLE
Fix container resize during image load

### DIFF
--- a/components/ImageStrip.vue
+++ b/components/ImageStrip.vue
@@ -293,6 +293,7 @@ const handleCurrentSessionClick = () => {
   position: relative;
   flex-shrink: 0;
   width: 100%; /* Take full width of container */
+  min-height: 80px; /* Maintain height until image loads */
   /* Remove fixed height to respect aspect ratio */
   border-radius: 6px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- keep image item height stable while loading by adding min-height

## Testing
- `pnpm lint` *(fails: 848 problems)*
- `pnpm test` *(fails to find package 'happy-dom')*


------
https://chatgpt.com/codex/tasks/task_e_6872508d30088323980247f3ae3945f2